### PR TITLE
Update blog entry on PaperTrail

### DIFF
--- a/blog/2015/03/03/versioning-with-papertrail-on-rails/index.html
+++ b/blog/2015/03/03/versioning-with-papertrail-on-rails/index.html
@@ -442,7 +442,11 @@
 </tr>
 <tr>
 <td>version.event </td>
-<td> The action applied to the resource (create, update, destroy).version.object, Full dump of the resource that was changed.</td>
+<td> The action applied to the resource (create, update, destroy).</td>
+</tr>
+<tr>
+<td>version.object </td>
+<td> Full dump of the resource that was changed.</td>
 </tr>
 </tbody>
 </table>


### PR DESCRIPTION
The `version#object` row is hidden inside the `version#event` row.

Before:
![Screenshot_2019-05-16 Versioning with PaperTrail on Rails - GeeKhmer](https://user-images.githubusercontent.com/193455/57841777-166bc380-77c3-11e9-8990-56bb60b668f9.png)

After:
![Screenshot_2019-05-16 Versioning with PaperTrail on Rails - GeeKhmer(1)](https://user-images.githubusercontent.com/193455/57841785-1a97e100-77c3-11e9-8ece-196558379db6.png)
